### PR TITLE
Move error handling to the server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,9 @@ name = "yesser-todo-server"
 version = "1.0.0"
 dependencies = [
  "axum",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "yesser-todo-db 2.0.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2215,6 +2215,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "yesser-todo-db 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yesser-todo-errors",
 ]
 
 [[package]]
@@ -2228,6 +2229,7 @@ dependencies = [
  "url",
  "yesser-todo-api",
  "yesser-todo-db 2.0.0",
+ "yesser-todo-errors",
 ]
 
 [[package]]
@@ -2238,6 +2240,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "yesser-todo-errors",
 ]
 
 [[package]]
@@ -2253,6 +2256,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "yesser-todo-errors"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "yesser-todo-server"
 version = "1.0.0"
 dependencies = [
@@ -2262,6 +2276,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "yesser-todo-db 2.0.0",
+ "yesser-todo-errors",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "3"
-members = ["cli", "api", "db", "server"]
+members = ["cli", "api", "db", "server", "errors"]
 
 [profile.release]
 strip = true

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/Yesser-Studios/yesser-todo-cli"
 reqwest = { version = "0", features = ["json"] }
 thiserror = "2.0.18"
 yesser-todo-db = "2"
+yesser-todo-errors = { version = "0.1", path = "../errors" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"] }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,9 +1,7 @@
-pub mod api_error;
-
 use reqwest::StatusCode;
 use yesser_todo_db::Task;
 
-use crate::api_error::ApiError;
+pub use yesser_todo_errors::api_error::ApiError;
 
 pub const DEFAULT_PORT: &str = "6982";
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -2,6 +2,7 @@ use reqwest::StatusCode;
 use yesser_todo_db::Task;
 
 pub use yesser_todo_errors::api_error::ApiError;
+use yesser_todo_errors::server_error::ServerError;
 
 pub const DEFAULT_PORT: &str = "6982";
 
@@ -72,7 +73,10 @@ impl Client {
                         Err(err) => Err(ApiError::RequestError(err)),
                     }
                 } else {
-                    Err(ApiError::HTTPError(status_code))
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),
@@ -116,7 +120,10 @@ impl Client {
                         Err(err) => Err(ApiError::RequestError(err)),
                     }
                 } else {
-                    Err(ApiError::HTTPError(status_code))
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),
@@ -155,7 +162,10 @@ impl Client {
                         Err(err) => Err(ApiError::RequestError(err)),
                     }
                 } else {
-                    Err(ApiError::HTTPError(status_code))
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),
@@ -183,13 +193,11 @@ impl Client {
     /// ```
     pub async fn remove(&self, task_name: &str) -> Result<StatusCode, ApiError> {
         let index_result = self.get_index(task_name).await;
-        let index: usize;
-        match index_result {
-            Ok((_, result)) => {
-                index = result;
-            }
+        let index = match index_result {
+            Ok((_, result)) => result,
             Err(err) => return Err(err),
-        }
+        };
+
         let result = self
             .client
             .delete(format!("{}:{}/remove", self.hostname, self.port).as_str())
@@ -201,7 +209,11 @@ impl Client {
                 if result.status().is_success() {
                     Ok(result.status())
                 } else {
-                    Err(ApiError::HTTPError(result.status()))
+                    let status_code = result.status();
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),
@@ -257,7 +269,11 @@ impl Client {
                         Err(err) => Err(ApiError::RequestError(err)),
                     }
                 } else {
-                    Err(ApiError::HTTPError(status_code))
+                    let status_code = result.status();
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),
@@ -285,16 +301,16 @@ impl Client {
     /// ```
     pub async fn undone(&self, task_name: &str) -> Result<(StatusCode, Task), ApiError> {
         let index_result = self.get_index(task_name).await;
-        let index: usize;
-        match index_result {
+        let index = match index_result {
             Ok((status_code, result)) => {
                 if !status_code.is_success() {
                     return Err(ApiError::HTTPError(status_code));
                 }
-                index = result;
+                result
             }
             Err(err) => return Err(err),
-        }
+        };
+
         let result = self
             .client
             .post(format!("{}:{}/undone", self.hostname, self.port).as_str())
@@ -311,7 +327,11 @@ impl Client {
                         Err(err) => Err(ApiError::RequestError(err)),
                     }
                 } else {
-                    Err(ApiError::HTTPError(status_code))
+                    let status_code = result.status();
+                    match result.json::<ServerError>().await {
+                        Ok(err) => Err(ApiError::ServerError(err)),
+                        Err(_) => Err(ApiError::HTTPError(status_code)),
+                    }
                 }
             }
             Err(err) => Err(ApiError::RequestError(err)),

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -234,17 +234,15 @@ impl Client {
     /// # }
     /// ```
     pub async fn done(&self, task_name: &str) -> Result<(StatusCode, Task), ApiError> {
-        let index_result = self.get_index(task_name).await;
-        let index: usize;
-        match index_result {
+        let index = match self.get_index(task_name).await {
             Ok((status_code, result)) => {
                 if !status_code.is_success() {
                     return Err(ApiError::HTTPError(status_code));
                 }
-                index = result;
+                result
             }
             Err(err) => return Err(err),
-        }
+        };
         let result = self
             .client
             .post(format!("{}:{}/done", self.hostname, self.port).as_str())

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -22,6 +22,7 @@ yesser-todo-api = { version = "2", path = "../api" }
 tokio = { version = "1", features = ["full"] }
 thiserror = "2"
 url = "2"
+yesser-todo-errors = { version = "0.1", path = "../errors" }
 
 # yesser-todo-db = {path = "../db"}
 # yesser-todo-api = {path = "../api"}

--- a/cli/src/bin/todo/args.rs
+++ b/cli/src/bin/todo/args.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 use yesser_todo_api::Client;
 use yesser_todo_db::Task;
+use yesser_todo_errors::command_error::CommandError;
 
 use crate::command_impl::*;
 use crate::command_impl_cloud::*;
@@ -94,7 +95,7 @@ impl Command {
     /// cmd.execute(&mut tasks, &mut client).await?;
     /// # Ok(()) }
     /// ```
-    pub(crate) async fn execute(&self, data: &mut Vec<Task>, client: &mut Option<Client>) -> Result<(), crate::command_error::CommandError> {
+    pub(crate) async fn execute(&self, data: &mut Vec<Task>, client: &mut Option<Client>) -> Result<(), CommandError> {
         match client {
             None => match self {
                 Command::Add(tasks_command) => handle_add(tasks_command, data),
@@ -124,7 +125,7 @@ impl Command {
     }
 }
 
-fn handle_cloud_subcommand(cloud_subcommand: &CloudSubcommand) -> Result<(), crate::command_error::CommandError> {
+fn handle_cloud_subcommand(cloud_subcommand: &CloudSubcommand) -> Result<(), CommandError> {
     match cloud_subcommand {
         CloudSubcommand::Connect(cloud_command) => handle_connect(cloud_command),
         CloudSubcommand::Disconnect => handle_disconnect(),

--- a/cli/src/bin/todo/args.rs
+++ b/cli/src/bin/todo/args.rs
@@ -79,7 +79,7 @@ impl Command {
     ///
     /// # Returns
     ///
-    /// `Ok(())` on success, or a `crate::command_error::CommandError` on failure.
+    /// `Ok(())` on success, or a `yesser_todo_errors::command_error::CommandError` on failure.
     ///
     /// # Examples
     ///

--- a/cli/src/bin/todo/command_impl.rs
+++ b/cli/src/bin/todo/command_impl.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
+use yesser_todo_errors::command_error::CommandError;
 
 use crate::{args::ClearCommand, utils::DONE_STYLE};
 use yesser_todo_db::{Task, get_index};
 
-use crate::{args::TasksCommand, command_error::CommandError};
+use crate::args::TasksCommand;
 
 /// Adds each task named in `command.tasks` to `data` after validating input.
 ///
@@ -551,3 +552,4 @@ mod tests {
         assert_eq!(data.len(), 0);
     }
 }
+

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -77,11 +77,16 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
                     });
                 }
                 ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: "".into() }),
-                ApiError::ServerError(server_error) => {
-                    return Err(CommandError::HTTPError {
-                        name: "".into(),
-                        status_code: server_error.to_status_code().as_u16(),
-                    });
+                ApiError::ServerError(server_error) => match server_error {
+                    yesser_todo_errors::server_error::ServerError::NotFound(_) => {
+                        return Err(CommandError::TaskNotFound { name: "".into() });
+                    }
+                    other => {
+                        return Err(CommandError::HTTPError {
+                            name: "".into(),
+                            status_code: other.to_status_code().as_u16(),
+                        });
+                    }
                 }
             };
         }

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -54,6 +54,13 @@ pub(crate) async fn check_exists_cloud(task: &str, client: &Client) -> Result<bo
                 }
             }
             ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: task.to_string() }),
+            ApiError::ServerError(server_error) => match server_error {
+                yesser_todo_errors::server_error::ServerError::NotFound(_) => Ok(false),
+                _ => Err(CommandError::HTTPError {
+                    name: task.to_string(),
+                    status_code: server_error.to_status_code().as_u16(),
+                }),
+            },
         },
     }
 }
@@ -70,6 +77,12 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
                     });
                 }
                 ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: "".into() }),
+                ApiError::ServerError(server_error) => {
+                    return Err(CommandError::HTTPError {
+                        name: "".into(),
+                        status_code: server_error.to_status_code().as_u16(),
+                    });
+                }
             };
         }
     };
@@ -128,6 +141,12 @@ pub(crate) async fn handle_add_cloud(command: &TasksCommand, client: &mut Client
                     });
                 }
                 ApiError::RequestError(_) => return Err(CommandError::ConnectionError { name: task.clone() }),
+                ApiError::ServerError(server_error) => {
+                    return Err(CommandError::HTTPError {
+                        name: task.clone(),
+                        status_code: server_error.to_status_code().as_u16(),
+                    });
+                }
             }
         };
     }
@@ -180,6 +199,12 @@ pub(crate) async fn handle_remove_cloud(command: &TasksCommand, client: &mut Cli
                     });
                 }
                 ApiError::RequestError(_) => return Err(CommandError::ConnectionError { name: task.clone() }),
+                ApiError::ServerError(server_error) => {
+                    return Err(CommandError::HTTPError {
+                        name: task.clone(),
+                        status_code: server_error.to_status_code().as_u16(),
+                    });
+                }
             }
         }
     }
@@ -226,6 +251,12 @@ pub(crate) async fn handle_list_cloud(client: &Client) -> Result<(), CommandErro
             }
             ApiError::RequestError(_) => {
                 return Err(CommandError::ConnectionError { name: "".to_string() });
+            }
+            ApiError::ServerError(server_error) => {
+                return Err(CommandError::HTTPError {
+                    name: "".to_string(),
+                    status_code: server_error.to_status_code().as_u16(),
+                });
             }
         },
     }
@@ -287,6 +318,12 @@ pub(crate) async fn handle_done_undone_cloud(command: &TasksCommand, client: &mu
                 }
 
                 ApiError::RequestError(_) => return Err(CommandError::ConnectionError { name: task.clone() }),
+                ApiError::ServerError(server_error) => {
+                    return Err(CommandError::HTTPError {
+                        name: task.clone(),
+                        status_code: server_error.to_status_code().as_u16(),
+                    });
+                }
             },
         }
     }
@@ -319,6 +356,10 @@ pub(crate) async fn handle_clear_cloud(command: &ClearCommand, client: &mut Clie
                 status_code: status_code.as_u16(),
             }),
             ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: "".to_string() }),
+            ApiError::ServerError(server_error) => Err(CommandError::HTTPError {
+                name: "".to_string(),
+                status_code: server_error.to_status_code().as_u16(),
+            }),
         },
     }
 }

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -79,7 +79,10 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
                 ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: "".into() }),
                 ApiError::ServerError(server_error) => match server_error {
                     yesser_todo_errors::server_error::ServerError::NotFound(_) => {
-                        return Err(CommandError::TaskNotFound { name: "".into() });
+                        return Err(CommandError::HTTPError {
+                            name: "".into(),
+                            status_code: 404,
+                        });
                     }
                     other => {
                         return Err(CommandError::HTTPError {

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashSet, io::ErrorKind};
 
 use url::Url;
-use yesser_todo_api::{Client, DEFAULT_PORT, api_error::ApiError};
-use yesser_todo_db::{SaveData, Task};
+use yesser_todo_api::{ApiError, Client, DEFAULT_PORT};
+use yesser_todo_db::{DatabaseError, SaveData, Task};
+use yesser_todo_errors::command_error::CommandError;
 
 use crate::{
     args::{ClearCommand, CloudCommand, TasksCommand},
-    command_error::CommandError,
     utils::DONE_STYLE,
 };
 
@@ -73,13 +73,13 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
             };
         }
     };
-    return Ok(current_tasks
+    Ok(current_tasks
         .iter()
         .map(|t| Task {
             name: t.name.clone(),
             done: t.done,
         })
-        .collect());
+        .collect())
 }
 
 /// Adds one or more tasks to the cloud after validating input and existence.
@@ -102,7 +102,7 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
 /// // block_on(handle_add_cloud(&command, &mut client)).unwrap();
 /// ```
 pub(crate) async fn handle_add_cloud(command: &TasksCommand, client: &mut Client) -> Result<(), CommandError> {
-    if command.tasks.len() <= 0 {
+    if command.tasks.is_empty() {
         return Err(CommandError::NoTasksSpecified);
     }
 
@@ -119,8 +119,8 @@ pub(crate) async fn handle_add_cloud(command: &TasksCommand, client: &mut Client
 
     let results = command.tasks.iter().map(|task| (client.add(task), task));
     for (result, task) in results {
-        match result.await {
-            Err(err) => match err {
+        if let Err(err) = result.await {
+            match err {
                 ApiError::HTTPError(status_code) => {
                     return Err(CommandError::HTTPError {
                         name: task.clone(),
@@ -128,8 +128,7 @@ pub(crate) async fn handle_add_cloud(command: &TasksCommand, client: &mut Client
                     });
                 }
                 ApiError::RequestError(_) => return Err(CommandError::ConnectionError { name: task.clone() }),
-            },
-            Ok(_) => {}
+            }
         };
     }
     Ok(())
@@ -155,7 +154,7 @@ pub(crate) async fn handle_add_cloud(command: &TasksCommand, client: &mut Client
 /// # Ok(()) }
 /// ```
 pub(crate) async fn handle_remove_cloud(command: &TasksCommand, client: &mut Client) -> Result<(), CommandError> {
-    if command.tasks.len() <= 0 {
+    if command.tasks.is_empty() {
         return Err(CommandError::NoTasksSpecified);
     }
 
@@ -172,8 +171,8 @@ pub(crate) async fn handle_remove_cloud(command: &TasksCommand, client: &mut Cli
 
     let results = command.tasks.iter().map(|task| (client.remove(task), task));
     for (result, task) in results {
-        match result.await {
-            Err(err) => match err {
+        if let Err(err) = result.await {
+            match err {
                 ApiError::HTTPError(status_code) => {
                     return Err(CommandError::HTTPError {
                         name: task.clone(),
@@ -181,8 +180,7 @@ pub(crate) async fn handle_remove_cloud(command: &TasksCommand, client: &mut Cli
                     });
                 }
                 ApiError::RequestError(_) => return Err(CommandError::ConnectionError { name: task.clone() }),
-            },
-            Ok(_) => {}
+            }
         }
     }
 
@@ -257,7 +255,7 @@ pub(crate) async fn handle_list_cloud(client: &Client) -> Result<(), CommandErro
 ///
 /// `Ok(())` on success; `Err(CommandError)` on validation failures or API/connection errors.
 pub(crate) async fn handle_done_undone_cloud(command: &TasksCommand, client: &mut Client, done: bool) -> Result<(), CommandError> {
-    if command.tasks.len() <= 0 {
+    if command.tasks.is_empty() {
         return Err(CommandError::NoTasksSpecified);
     }
 
@@ -312,12 +310,7 @@ pub(crate) async fn handle_done_undone_cloud(command: &TasksCommand, client: &mu
 /// # }
 /// ```
 pub(crate) async fn handle_clear_cloud(command: &ClearCommand, client: &mut Client) -> Result<(), CommandError> {
-    let result;
-    if command.done {
-        result = client.clear_done().await;
-    } else {
-        result = client.clear().await;
-    }
+    let result = if command.done { client.clear_done().await } else { client.clear().await };
     match result {
         Ok(_) => Ok(()),
         Err(err) => match err {
@@ -371,7 +364,7 @@ pub(crate) fn parse_url(url: &str) -> Result<Url, CommandError> {
     let parsed = Url::parse(url).map_err(|x| CommandError::InvalidUrlError {
         why: format!(
             "{}{}",
-            x.to_string(),
+            x,
             if url.to_string().matches(':').count() >= 3 {
                 // One ':' is before scheme and one before port
                 "\nHelp: Did you mean to wrap IPv6 address with []?"
@@ -528,10 +521,10 @@ pub(crate) fn handle_disconnect() -> Result<(), CommandError> {
             Ok(())
         }
         Err(err) => match err {
-            yesser_todo_db::db_error::DatabaseError::IOError(io_err) if io_err.kind() == ErrorKind::NotFound => Err(CommandError::UnlinkedError),
+            DatabaseError::IOError(io_err) if io_err.kind() == ErrorKind::NotFound => Err(CommandError::UnlinkedError),
             _ => Err(CommandError::DataError {
-                what: format!("configuration"),
-                err: err,
+                what: "configuration".to_string(),
+                err,
             }),
         },
     }
@@ -560,8 +553,14 @@ pub(crate) fn handle_disconnect() -> Result<(), CommandError> {
 pub(crate) fn handle_show_server() -> Result<(), CommandError> {
     match SaveData::get_cloud_config() {
         Ok(data) => match data {
-            Some((hostname, port)) => Ok(println!("Hostname: {}, port: {}", hostname, port)),
-            None => Ok(println!("You're not connected to a server!")),
+            Some((hostname, port)) => {
+                println!("Hostname: {}, port: {}", hostname, port);
+                Ok(())
+            }
+            None => {
+                println!("You're not connected to a server!");
+                Ok(())
+            }
         },
         Err(e) => Err(CommandError::DataError {
             what: "configuration".to_string(),

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -71,24 +71,24 @@ pub(crate) async fn get_tasks_cloud(client: &Client) -> Result<Vec<Task>, Comman
         Err(err) => {
             return match err {
                 ApiError::HTTPError(status_code) => {
-                    return Err(CommandError::HTTPError {
+                    Err(CommandError::HTTPError {
                         name: "".into(),
                         status_code: status_code.as_u16(),
-                    });
+                    })
                 }
                 ApiError::RequestError(_) => Err(CommandError::ConnectionError { name: "".into() }),
                 ApiError::ServerError(server_error) => match server_error {
                     yesser_todo_errors::server_error::ServerError::NotFound(_) => {
-                        return Err(CommandError::HTTPError {
+                        Err(CommandError::HTTPError {
                             name: "".into(),
                             status_code: 404,
-                        });
+                        })
                     }
                     other => {
-                        return Err(CommandError::HTTPError {
+                        Err(CommandError::HTTPError {
                             name: "".into(),
                             status_code: other.to_status_code().as_u16(),
-                        });
+                        })
                     }
                 }
             };

--- a/cli/src/bin/todo/main.rs
+++ b/cli/src/bin/todo/main.rs
@@ -1,5 +1,4 @@
 mod args;
-mod command_error;
 mod command_impl;
 mod command_impl_cloud;
 mod utils;

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -18,3 +18,4 @@ serde_json = "1"
 platform-dirs = "0.3"
 serde = { version = "1", features = ["derive"] }
 thiserror = "2"
+yesser-todo-errors = { version = "0.1", path = "../errors" }

--- a/db/src/db_error.rs
+++ b/db/src/db_error.rs
@@ -135,3 +135,4 @@ mod tests {
         assert!(matches!(db_err, DatabaseError::JsonError(_)));
     }
 }
+

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,5 +1,3 @@
-pub mod db_error;
-
 use std::{
     fs::{self, File},
     path::PathBuf,
@@ -9,7 +7,7 @@ use platform_dirs::AppDirs;
 use serde::{Deserialize, Serialize};
 use serde_json::{from_reader, to_writer};
 
-use crate::db_error::DatabaseError;
+pub use yesser_todo_errors::db_error::DatabaseError;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct Task {
@@ -798,3 +796,4 @@ mod tests {
         assert_eq!(save_data.tasks[1].name, "task3");
     }
 }
+

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "yesser-todo-errors"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+axum = { version = "0.8.8", features = ["macros"] }
+reqwest = { version = "0.13.2", features = ["json"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+thiserror = "2.0.18"

--- a/errors/src/api_error.rs
+++ b/errors/src/api_error.rs
@@ -19,7 +19,7 @@ impl Display for ApiError {
     ///
     /// ```
     /// use reqwest::StatusCode;
-    /// use yesser_todo_api::api_error::ApiError;
+    /// use yesser_todo_errors::api_error::ApiError;
     /// // `ApiError` is defined in the current crate module where this formatter lives.
     /// let err = ApiError::HTTPError(StatusCode::BAD_REQUEST);
     /// assert_eq!(format!("{}", err), format!("Server returned HTTP error code {}",
@@ -35,8 +35,6 @@ impl Display for ApiError {
 
 #[cfg(test)]
 mod tests {
-    use crate::Client;
-
     use super::*;
 
     #[test]
@@ -61,19 +59,6 @@ mod tests {
     fn test_http_error_display_unauthorized() {
         let err = ApiError::HTTPError(StatusCode::UNAUTHORIZED);
         assert_eq!(format!("{}", err), "Server returned HTTP error code 401 Unauthorized");
-    }
-
-    #[tokio::test]
-    async fn test_request_error_display() {
-        let client = Client::new("http://example.invalid".to_string(), None);
-        let result = client.get().await;
-        assert!(result.is_err());
-        let req_err = result.unwrap_err();
-        if let ApiError::RequestError(_) = req_err {
-            assert_eq!(format!("{}", req_err), "Failed to connect to server");
-        } else {
-            panic!("API error is not a RequestError");
-        }
     }
 
     #[test]
@@ -105,4 +90,3 @@ mod tests {
         }
     }
 }
-

--- a/errors/src/api_error.rs
+++ b/errors/src/api_error.rs
@@ -3,8 +3,11 @@ use std::fmt::Display;
 use reqwest::StatusCode;
 use thiserror::Error;
 
+use crate::server_error::ServerError;
+
 #[derive(Debug, Error)]
 pub enum ApiError {
+    ServerError(ServerError),
     HTTPError(StatusCode),
     RequestError(reqwest::Error),
 }
@@ -27,8 +30,9 @@ impl Display for ApiError {
     /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            ApiError::HTTPError(status_code) => write!(f, "Server returned HTTP error code {status_code}"),
-            ApiError::RequestError(_) => write!(f, "Failed to connect to server"),
+            Self::ServerError(err) => err.fmt(f),
+            Self::HTTPError(status_code) => write!(f, "Server returned HTTP error code {status_code}"),
+            Self::RequestError(_) => write!(f, "Failed to connect to server"),
         }
     }
 }
@@ -88,5 +92,25 @@ mod tests {
             let err = ApiError::HTTPError(status);
             assert_eq!(format!("{}", err), expected);
         }
+    }
+
+    #[test]
+    fn test_server_error_display_not_found() {
+        use crate::server_error::TaskSelector;
+        let err = ApiError::ServerError(ServerError::NotFound(TaskSelector::Name("test task".into())));
+        assert_eq!(format!("{}", err), "Task test task not found!");
+    }
+
+    #[test]
+    fn test_server_error_display_conflict() {
+        use crate::server_error::TaskSelector;
+        let err = ApiError::ServerError(ServerError::Conflict(TaskSelector::Index(1)));
+        assert_eq!(format!("{}", err), "Task of index 1 already exists!");
+    }
+
+    #[test]
+    fn test_server_error_display_io_error() {
+        let err = ApiError::ServerError(ServerError::IOError("database connection failed".into()));
+        assert_eq!(format!("{}", err), "IO error: database connection failed");
     }
 }

--- a/errors/src/command_error.rs
+++ b/errors/src/command_error.rs
@@ -1,10 +1,11 @@
 use std::fmt::{self, Display, Formatter};
 
 use thiserror::Error;
-use yesser_todo_db::db_error::DatabaseError;
+
+use crate::db_error::DatabaseError;
 
 #[derive(Debug, Error)]
-pub(crate) enum CommandError {
+pub enum CommandError {
     NoTasksSpecified,
     TaskExists { name: String },
     TaskNotFound { name: String },
@@ -24,12 +25,12 @@ impl CommandError {
     /// # Examples
     ///
     /// ```
-    /// use crate::CommandError;
+    /// use yesser_todo_errors::command_error::CommandError;
     ///
     /// let err = CommandError::NoTasksSpecified;
     /// err.handle(); // prints "No tasks specified!" to stderr
     /// ```
-    pub(crate) fn handle(&self) {
+    pub fn handle(&self) {
         eprintln!("{self}")
     }
 }
@@ -40,7 +41,7 @@ impl Display for CommandError {
     /// # Examples
     ///
     /// ```
-    /// use crate::CommandError;
+    /// use yesser_todo_errors::command_error::CommandError;
     ///
     /// assert_eq!(
     ///     format!("{}", CommandError::TaskNotFound { name: "foo".into() }),
@@ -219,9 +220,7 @@ mod tests {
 
     #[test]
     fn test_invalid_url_error_with_empty_reason() {
-        let err = CommandError::InvalidUrlError {
-            why: String::new(),
-        };
+        let err = CommandError::InvalidUrlError { why: String::new() };
         assert_eq!(format!("{}", err), "Invalid URL: ");
     }
 
@@ -237,9 +236,7 @@ mod tests {
 
     #[test]
     fn test_invalid_url_error_debug() {
-        let err = CommandError::InvalidUrlError {
-            why: "test".to_string(),
-        };
+        let err = CommandError::InvalidUrlError { why: "test".to_string() };
         let debug_str = format!("{:?}", err);
         assert!(debug_str.contains("InvalidUrlError"));
         assert!(debug_str.contains("test"));

--- a/errors/src/db_error.rs
+++ b/errors/src/db_error.rs
@@ -18,7 +18,7 @@ impl From<serde_json::Error> for DatabaseError {
     /// # Examples
     ///
     /// ```
-    /// use yesser_todo_db::db_error::DatabaseError;
+    /// use yesser_todo_errors::db_error::DatabaseError;
     /// let serde_err = serde_json::from_str::<serde_json::Value>("not json").unwrap_err();
     /// let db_err = DatabaseError::from(serde_err);
     /// assert!(matches!(db_err, DatabaseError::JsonError(_)));
@@ -34,7 +34,7 @@ impl From<std::io::Error> for DatabaseError {
     /// # Examples
     ///
     /// ```
-    /// use yesser_todo_db::db_error::DatabaseError;
+    /// use yesser_todo_errors::db_error::DatabaseError;
     /// let io_err = std::io::Error::new(std::io::ErrorKind::Other, "oops");
     /// let db_err = DatabaseError::from(io_err);
     /// match db_err {
@@ -135,4 +135,3 @@ mod tests {
         assert!(matches!(db_err, DatabaseError::JsonError(_)));
     }
 }
-

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod api_error;
+pub mod command_error;
+pub mod db_error;
+pub mod server_error;

--- a/errors/src/server_error.rs
+++ b/errors/src/server_error.rs
@@ -2,15 +2,17 @@ use std::fmt::Display;
 
 use axum::{http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
-use serde_json::json;
 use thiserror::Error;
 
 use crate::db_error::DatabaseError;
 
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ServerError {
+    #[error("{0} not found!")]
     NotFound(TaskSelector),
+    #[error("{0} already exists!")]
     Conflict(TaskSelector),
+    #[error("IO error: {0}")]
     IOError(String),
 }
 
@@ -27,16 +29,6 @@ impl ServerError {
 impl From<DatabaseError> for ServerError {
     fn from(value: DatabaseError) -> Self {
         Self::IOError(format!("{value}"))
-    }
-}
-
-impl Display for ServerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ServerError::NotFound(selector) => write!(f, "{selector} not found!"),
-            ServerError::Conflict(selector) => write!(f, "{selector} already exists!"),
-            ServerError::IOError(error) => write!(f, "IO error: {error}"),
-        }
     }
 }
 

--- a/errors/src/server_error.rs
+++ b/errors/src/server_error.rs
@@ -4,7 +4,8 @@ use axum::{Json, http::StatusCode, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
-use yesser_todo_db::db_error::DatabaseError;
+
+use crate::db_error::DatabaseError;
 
 #[derive(Debug, Error, Serialize, Deserialize)]
 pub enum ServerError {

--- a/errors/src/server_error.rs
+++ b/errors/src/server_error.rs
@@ -1,6 +1,6 @@
 use std::fmt::Display;
 
-use axum::{Json, http::StatusCode, response::IntoResponse};
+use axum::{http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use thiserror::Error;
@@ -12,6 +12,16 @@ pub enum ServerError {
     NotFound(TaskSelector),
     Conflict(TaskSelector),
     IOError(String),
+}
+
+impl ServerError {
+    pub fn to_status_code(&self) -> StatusCode {
+        match self {
+            ServerError::NotFound(_) => StatusCode::NOT_FOUND,
+            ServerError::Conflict(_) => StatusCode::CONFLICT,
+            ServerError::IOError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
 }
 
 impl From<DatabaseError> for ServerError {
@@ -32,12 +42,7 @@ impl Display for ServerError {
 
 impl IntoResponse for ServerError {
     fn into_response(self) -> axum::response::Response {
-        let status = match &self {
-            ServerError::NotFound(_) => StatusCode::NOT_FOUND,
-            ServerError::Conflict(_) => StatusCode::CONFLICT,
-            ServerError::IOError(_) => StatusCode::INTERNAL_SERVER_ERROR,
-        };
-        (status, Json(json!({"error": &self}))).into_response()
+        (self.to_status_code(), Json(json!({"error": &self}))).into_response()
     }
 }
 
@@ -81,5 +86,58 @@ impl From<usize> for TaskSelector {
 impl From<String> for TaskSelector {
     fn from(value: String) -> Self {
         Self::Name(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_status_code_not_found() {
+        let err = ServerError::NotFound(TaskSelector::Name("test".into()));
+        assert_eq!(err.to_status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[test]
+    fn test_to_status_code_conflict() {
+        let err = ServerError::Conflict(TaskSelector::Index(1));
+        assert_eq!(err.to_status_code(), StatusCode::CONFLICT);
+    }
+
+    #[test]
+    fn test_to_status_code_io_error() {
+        let err = ServerError::IOError("test error".into());
+        assert_eq!(err.to_status_code(), StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_display_not_found() {
+        let err = ServerError::NotFound(TaskSelector::Name("my task".into()));
+        assert_eq!(format!("{}", err), "Task my task not found!");
+    }
+
+    #[test]
+    fn test_display_conflict_index() {
+        let err = ServerError::Conflict(TaskSelector::Index(5));
+        assert_eq!(format!("{}", err), "Task of index 5 already exists!");
+    }
+
+    #[test]
+    fn test_display_io_error() {
+        let err = ServerError::IOError("disk full".into());
+        assert_eq!(format!("{}", err), "IO error: disk full");
+    }
+
+    #[test]
+    fn test_task_selector_display_index() {
+        let selector = TaskSelector::Index(42);
+        assert_eq!(format!("{}", selector), "Task of index 42");
+    }
+
+    #[test]
+    fn test_task_selector_display_name() {
+        let selector = TaskSelector::Name("buy milk".into());
+        assert_eq!(format!("{}", selector), "Task buy milk");
     }
 }

--- a/errors/src/server_error.rs
+++ b/errors/src/server_error.rs
@@ -42,7 +42,8 @@ impl Display for ServerError {
 
 impl IntoResponse for ServerError {
     fn into_response(self) -> axum::response::Response {
-        (self.to_status_code(), Json(json!({"error": &self}))).into_response()
+        let status = self.to_status_code();
+        (status, Json(self)).into_response()
     }
 }
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 160
+fn_params_layout = "Compressed"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = "1.0.149"
 thiserror = "2.0.18"
 tokio = { version = "1.47.1", features = ["full"] }
 yesser-todo-db = { version = "2", path = "../db" }
+yesser-todo-errors = { version = "0.1", path = "../errors" }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,5 +12,8 @@ repository = "https://github.com/Yesser-Studios/yesser-todo-cli"
 
 [dependencies]
 axum = { version = "0.8.6", features = ["http2", "macros", "ws"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+thiserror = "2.0.18"
 tokio = { version = "1.47.1", features = ["full"] }
 yesser-todo-db = { version = "2", path = "../db" }

--- a/server/src/functions.rs
+++ b/server/src/functions.rs
@@ -2,6 +2,8 @@ use axum::http::StatusCode;
 use axum::{Json, debug_handler};
 use yesser_todo_db::{SaveData, Task};
 
+use crate::server_error::ServerError;
+
 /// Returns the current list of stored tasks as JSON.
 ///
 /// # Examples
@@ -11,11 +13,10 @@ use yesser_todo_db::{SaveData, Task};
 /// let tasks = json.0; // Vec<Task>
 /// ```
 #[debug_handler]
-pub async fn get_tasks() -> Json<Vec<Task>> {
+pub async fn get_tasks() -> Result<(StatusCode, Json<Vec<Task>>), ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
-    let tasks = save_data.get_tasks().clone();
-    Json(tasks)
+    save_data.load_tasks()?;
+    Ok((StatusCode::OK, Json(save_data.get_tasks().clone())))
 }
 
 /// Creates and persists a new task with the given name.
@@ -35,14 +36,18 @@ pub async fn get_tasks() -> Json<Vec<Task>> {
 /// # }
 /// ```
 #[debug_handler]
-pub async fn add_task(Json(name): Json<String>) -> Json<Task> {
+pub async fn add_task(Json(name): Json<String>) -> Result<(StatusCode, Json<Task>), ServerError> {
     println!("Adding task {}", name);
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
+    save_data.load_tasks()?;
+    if save_data.get_tasks().iter().any(|t| t.name == name) {
+        return Err(ServerError::Conflict(name.into()));
+    }
+
     let task = Task { name, done: false };
     save_data.add_task(task.clone());
-    save_data.save_tasks().unwrap();
-    Json(task)
+    save_data.save_tasks()?;
+    Ok((StatusCode::OK, Json(task)))
 }
 
 /// Remove the task at the given zero-based index.
@@ -65,16 +70,17 @@ pub async fn add_task(Json(name): Json<String>) -> Json<Task> {
 /// // assert!(resp == StatusCode::OK || resp == StatusCode::NOT_FOUND);
 /// ```
 #[debug_handler]
-pub async fn remove_task(Json(index): Json<usize>) -> StatusCode {
+pub async fn remove_task(Json(index): Json<usize>) -> Result<StatusCode, ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
-    if save_data.get_tasks().len() <= index {
-        return StatusCode::NOT_FOUND;
-    }
+    save_data.load_tasks()?;
+
+    save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
+
     println!("Removing task with index {}: {}", index, save_data.get_tasks()[index].name);
     save_data.remove_task(index);
-    save_data.save_tasks().unwrap();
-    StatusCode::OK
+
+    save_data.save_tasks()?;
+    Ok(StatusCode::OK)
 }
 
 /// Mark the task at the given index as done.
@@ -95,22 +101,16 @@ pub async fn remove_task(Json(index): Json<usize>) -> StatusCode {
 /// # }
 /// ```
 #[debug_handler]
-pub async fn done_task(Json(index): Json<usize>) -> (StatusCode, Json<Task>) {
+pub async fn done_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
-    if save_data.get_tasks().len() <= index {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(Task {
-                name: "Could not find specified index".to_string(),
-                done: false,
-            }),
-        );
-    }
+    save_data.load_tasks()?;
+
+    save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
+
     println!("Marking task with index {} as done: {}", index, save_data.get_tasks()[index].name);
     save_data.mark_task_done(index);
-    save_data.save_tasks().unwrap();
-    (StatusCode::OK, Json(save_data.get_tasks()[index].clone()))
+    save_data.save_tasks()?;
+    Ok((StatusCode::OK, Json(save_data.get_tasks()[index].clone())))
 }
 
 /// Mark the task at the given index as not completed and persist the change.
@@ -134,22 +134,16 @@ pub async fn done_task(Json(index): Json<usize>) -> (StatusCode, Json<Task>) {
 /// # }
 /// ```
 #[debug_handler]
-pub async fn undone_task(Json(index): Json<usize>) -> (StatusCode, Json<Task>) {
+pub async fn undone_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
-    if save_data.get_tasks().len() <= index {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(Task {
-                name: "Could not find specified index".to_string(),
-                done: false,
-            }),
-        );
-    }
+    save_data.load_tasks()?;
+
+    save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
+
     println!("Marking task with index {} as undone: {}", index, save_data.get_tasks()[index].name);
     save_data.mark_task_undone(index);
-    save_data.save_tasks().unwrap();
-    (StatusCode::OK, Json(save_data.get_tasks()[index].clone()))
+    save_data.save_tasks()?;
+    Ok((StatusCode::OK, Json(save_data.get_tasks()[index].clone())))
 }
 
 /// Clears all tasks from persistent storage and persists the empty task list.
@@ -161,16 +155,17 @@ pub async fn undone_task(Json(index): Json<usize>) -> (StatusCode, Json<Task>) {
 /// ```
 /// # use server::functions::clear_tasks;
 /// # tokio_test::block_on(async {
-/// clear_tasks().await;
+/// clear_tasks().await.unwrap();
 /// # });
 /// ```
 #[debug_handler]
-pub async fn clear_tasks() {
+pub async fn clear_tasks() -> Result<StatusCode, ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
+    save_data.load_tasks()?;
     println!("Clearing tasks");
     save_data.clear_tasks();
-    save_data.save_tasks().unwrap();
+    save_data.save_tasks()?;
+    Ok(StatusCode::OK)
 }
 
 /// Remove all tasks that are marked as done and persist the updated task list.
@@ -185,12 +180,14 @@ pub async fn clear_tasks() {
 /// clear_done_tasks().await;
 /// ```
 #[debug_handler]
-pub async fn clear_done_tasks() {
+pub async fn clear_done_tasks() -> Result<StatusCode, ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
+    save_data.load_tasks()?;
+
     println!("Clearing done tasks");
     save_data.clear_done_tasks();
-    save_data.save_tasks().unwrap();
+    save_data.save_tasks()?;
+    Ok(StatusCode::OK)
 }
 
 /// Finds the index of a task by name and returns it as a JSON response.
@@ -217,13 +214,12 @@ pub async fn clear_done_tasks() {
 /// }
 /// ```
 #[debug_handler]
-pub async fn get_index(Json(name): Json<String>) -> (StatusCode, Json<usize>) {
+pub async fn get_index(Json(name): Json<String>) -> Result<(StatusCode, Json<usize>), ServerError> {
     let mut save_data = SaveData::new();
-    let _ = save_data.load_tasks();
-    let result = yesser_todo_db::get_index(save_data.get_tasks(), &name);
-    match result {
-        None => (StatusCode::NOT_FOUND, Json(0)),
-        Some(result) => (StatusCode::OK, Json(result)),
+    save_data.load_tasks()?;
+    match yesser_todo_db::get_index(save_data.get_tasks(), &name) {
+        None => Err(ServerError::NotFound(name.into())),
+        Some(result) => Ok((StatusCode::OK, Json(result))),
     }
 }
 
@@ -233,257 +229,268 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_tasks_empty() {
-        clear_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_add_task() {
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
         let task_name = "Test task".to_string();
-        let Json(task) = add_task(Json(task_name.clone())).await;
+        let (status, Json(task)) = add_task(Json(task_name.clone())).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(task.name, task_name);
         assert!(!task.done);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_add_multiple_tasks() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        add_task(Json("Task 3".to_string())).await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(Json("Task 3".to_string())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 3);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_remove_task_success() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        let status = remove_task(Json(0)).await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        let status = remove_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
-        let Json(tasks) = get_tasks().await;
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name, "Task 2");
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_remove_task_not_found() {
-        clear_tasks().await;
-        let status = remove_task(Json(0)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
+        clear_tasks().await.unwrap();
+        let err = remove_task(Json(0)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn test_remove_task_out_of_bounds() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        let status = remove_task(Json(10)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        let err = remove_task(Json(99)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_done_task_success() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        let (status, Json(task)) = done_task(Json(0)).await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
         assert_eq!(task.name, "Task 1");
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_done_task_not_found() {
-        clear_tasks().await;
-        let (status, Json(task)) = done_task(Json(0)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(task.name, "Could not find specified index");
-        assert!(!task.done);
+        clear_tasks().await.unwrap();
+        let err = done_task(Json(0)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)))
     }
 
     #[tokio::test]
     async fn test_done_task_out_of_bounds() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        let (status, Json(task)) = done_task(Json(5)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(task.name, "Could not find specified index");
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        let err = done_task(Json(5)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn test_undone_task_success() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        done_task(Json(0)).await;
-        let (status, Json(task)) = undone_task(Json(0)).await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = done_task(Json(0)).await.unwrap();
+        let (status, Json(task)) = undone_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(!task.done);
         assert_eq!(task.name, "Task 1");
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_undone_task_not_found() {
-        clear_tasks().await;
-        let (status, Json(task)) = undone_task(Json(0)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(task.name, "Could not find specified index");
-        assert!(!task.done);
+        clear_tasks().await.unwrap();
+        let err = undone_task(Json(0)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_undone_task_out_of_bounds() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        let (status, Json(task)) = undone_task(Json(10)).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        let err = undone_task(Json(10)).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_tasks() {
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        add_task(Json("Task 3".to_string())).await;
-        clear_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(Json("Task 3".to_string())).await.unwrap();
+        clear_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        add_task(Json("Task 3".to_string())).await;
-        done_task(Json(0)).await;
-        done_task(Json(2)).await;
-        clear_done_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(Json("Task 3".to_string())).await.unwrap();
+        _ = done_task(Json(0)).await.unwrap();
+        _ = done_task(Json(2)).await.unwrap();
+        _ = clear_done_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name, "Task 2");
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks_none_done() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        clear_done_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = clear_done_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 2);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks_all_done() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        done_task(Json(0)).await;
-        done_task(Json(1)).await;
-        clear_done_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = done_task(Json(0)).await.unwrap();
+        _ = done_task(Json(1)).await.unwrap();
+        clear_done_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_get_index_found() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        add_task(Json("Task 2".to_string())).await;
-        add_task(Json("Task 3".to_string())).await;
-        let (status, Json(index)) = get_index(Json("Task 2".to_string())).await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(Json("Task 3".to_string())).await.unwrap();
+        let (status, Json(index)) = get_index(Json("Task 2".to_string())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(index, 1);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_index_not_found() {
-        clear_tasks().await;
-        add_task(Json("Task 1".to_string())).await;
-        let (status, Json(index)) = get_index(Json("Nonexistent".to_string())).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(index, 0);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Task 1".to_string())).await.unwrap();
+        let err = get_index(Json("Nonexistent".to_string())).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)));
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_index_empty_list() {
-        clear_tasks().await;
-        let (status, Json(index)) = get_index(Json("Any task".to_string())).await;
-        assert_eq!(status, StatusCode::NOT_FOUND);
-        assert_eq!(index, 0);
+        clear_tasks().await.unwrap();
+        let err = get_index(Json("Any task".to_string())).await.unwrap_err();
+        assert!(matches!(err, ServerError::NotFound(_)))
     }
 
     #[tokio::test]
     async fn test_done_undone_cycle() {
-        clear_tasks().await;
-        add_task(Json("Cycle task".to_string())).await;
-        let (status, Json(task)) = done_task(Json(0)).await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Cycle task".to_string())).await.unwrap();
+        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
-        let (status, Json(task)) = undone_task(Json(0)).await;
+
+        let (status, Json(task)) = undone_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(!task.done);
-        let (status, Json(task)) = done_task(Json(0)).await;
+        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_workflow_add_done_clear() {
-        clear_tasks().await;
-        add_task(Json("Workflow task 1".to_string())).await;
-        add_task(Json("Workflow task 2".to_string())).await;
-        add_task(Json("Workflow task 3".to_string())).await;
-        done_task(Json(1)).await;
-        let Json(tasks) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Workflow task 1".to_string())).await.unwrap();
+        _ = add_task(Json("Workflow task 2".to_string())).await.unwrap();
+        _ = add_task(Json("Workflow task 3".to_string())).await.unwrap();
+        _ = done_task(Json(1)).await;
+
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 3);
         assert!(!tasks[0].done);
         assert!(tasks[1].done);
         assert!(!tasks[2].done);
-        clear_done_tasks().await;
-        let Json(tasks) = get_tasks().await;
+        _ = clear_done_tasks().await.unwrap();
+
+        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 2);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_add_task_with_special_characters() {
-        clear_tasks().await;
-        let special_name = "Task with spaces & symbols! @#$%".to_string();
-        let Json(task) = add_task(Json(special_name.clone())).await;
+        clear_tasks().await.unwrap();
+        let special_name = "Task with spaces & symbols! @#$%ᕚ( Ŧคภςץ )ᕘ".to_string();
+
+        let (status, Json(task)) = add_task(Json(special_name.clone())).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(task.name, special_name);
-        let (status, Json(index)) = get_index(Json(special_name)).await;
+
+        let (status, Json(index)) = get_index(Json(special_name)).await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(status, StatusCode::OK);
         assert_eq!(index, 0);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_persistence_across_operations() {
-        clear_tasks().await;
-        add_task(Json("Persist 1".to_string())).await;
-        add_task(Json("Persist 2".to_string())).await;
-        let Json(tasks_before) = get_tasks().await;
+        clear_tasks().await.unwrap();
+        _ = add_task(Json("Persist 1".to_string())).await.unwrap();
+        _ = add_task(Json("Persist 2".to_string())).await.unwrap();
+        let (status, Json(tasks_before)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks_before.len(), 2);
-        let Json(tasks_after) = get_tasks().await;
+        let (status, Json(tasks_after)) = get_tasks().await.unwrap();
+        assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks_after.len(), 2);
         assert_eq!(tasks_before[0].name, tasks_after[0].name);
         assert_eq!(tasks_before[1].name, tasks_after[1].name);
-        clear_tasks().await;
+        clear_tasks().await.unwrap();
     }
 }
-

--- a/server/src/functions.rs
+++ b/server/src/functions.rs
@@ -2,7 +2,7 @@ use axum::http::StatusCode;
 use axum::{Json, debug_handler};
 use yesser_todo_db::{SaveData, Task};
 
-use crate::server_error::ServerError;
+use yesser_todo_errors::server_error::ServerError;
 
 /// Returns the current list of stored tasks as JSON.
 ///

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,5 +1,4 @@
 mod functions;
-mod server_error;
 
 use crate::functions::{add_task, clear_done_tasks, clear_tasks, done_task, get_index, get_tasks, remove_task, undone_task};
 use axum::routing::delete;
@@ -35,4 +34,3 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:6982").await.unwrap();
     axum::serve(listener, router).await.unwrap();
 }
-

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,8 +1,12 @@
 mod functions;
+mod server_error;
 
 use crate::functions::{add_task, clear_done_tasks, clear_tasks, done_task, get_index, get_tasks, remove_task, undone_task};
 use axum::routing::delete;
-use axum::{routing::{get, post}, Router};
+use axum::{
+    Router,
+    routing::{get, post},
+};
 
 /// Binary entry point that configures HTTP routes and starts the Axum server.
 ///
@@ -31,3 +35,4 @@ async fn main() {
     let listener = tokio::net::TcpListener::bind("0.0.0.0:6982").await.unwrap();
     axum::serve(listener, router).await.unwrap();
 }
+

--- a/server/src/server_error.rs
+++ b/server/src/server_error.rs
@@ -1,0 +1,84 @@
+use std::fmt::Display;
+
+use axum::{Json, http::StatusCode, response::IntoResponse};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use thiserror::Error;
+use yesser_todo_db::db_error::DatabaseError;
+
+#[derive(Debug, Error, Serialize, Deserialize)]
+pub enum ServerError {
+    NotFound(TaskSelector),
+    Conflict(TaskSelector),
+    IOError(String),
+}
+
+impl From<DatabaseError> for ServerError {
+    fn from(value: DatabaseError) -> Self {
+        Self::IOError(format!("{value}"))
+    }
+}
+
+impl Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ServerError::NotFound(selector) => write!(f, "{selector} not found!"),
+            ServerError::Conflict(selector) => write!(f, "{selector} already exists!"),
+            ServerError::IOError(error) => write!(f, "IO error: {error}"),
+        }
+    }
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match &self {
+            ServerError::NotFound(_) => StatusCode::NOT_FOUND,
+            ServerError::Conflict(_) => StatusCode::CONFLICT,
+            ServerError::IOError(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (status, Json(json!({"error": &self}))).into_response()
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum TaskSelector {
+    Index(usize),
+    Name(String),
+}
+
+impl Display for TaskSelector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TaskSelector::Index(index) => write!(f, "Task of index {index}"),
+            TaskSelector::Name(name) => write!(f, "Task {name}"),
+        }
+    }
+}
+
+impl From<TaskSelector> for Option<String> {
+    fn from(val: TaskSelector) -> Self {
+        match val {
+            TaskSelector::Index(_) => None,
+            TaskSelector::Name(name) => Some(name),
+        }
+    }
+}
+impl From<TaskSelector> for Option<usize> {
+    fn from(val: TaskSelector) -> Self {
+        match val {
+            TaskSelector::Index(index) => Some(index),
+            TaskSelector::Name(_) => None,
+        }
+    }
+}
+
+impl From<usize> for TaskSelector {
+    fn from(value: usize) -> Self {
+        Self::Index(value)
+    }
+}
+impl From<String> for TaskSelector {
+    fn from(value: String) -> Self {
+        Self::Name(value)
+    }
+}


### PR DESCRIPTION
## Summary
- Add ServerError type with NotFound, Conflict, and IOError variants
- Update server handlers to return Result<T, ServerError> instead of using .unwrap()
- Extract shared error types into new yesser-todo-errors crate
- Update API client to parse ServerError from response body
- Update CLI to handle ApiError::ServerError and convert to CommandError::HTTPError

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server now returns structured JSON error responses with explicit status codes (404, 409, 500).
  * Add/remove operations detect duplicates and report conflicts.

* **Bug Fixes**
  * CLI and API surface detailed server error information instead of generic HTTP errors.
  * Not-found cases consistently report missing resources for clearer client handling.

* **Refactor**
  * Shared error types centralized and exposed for uniform error reporting across components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->