### PR TITLE
Fix server race conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,6 @@ Next, upload the generated `.msi` file to the GitHub release.
 2. Commit and push the changes. COPR should build the new commit automatically.
 
 # Server
-> [!CAUTION]
-> **Server functionality is not yet production-ready.**  
-> Accessing the server multiple times at the same time *will* cause race conditions and potentially edit incorrect tasks and/or crash the server.
 ## Usage guide:
 Run the `yesser-todo-server` crate. This will open port 6982 and listen for HTTP traffic.
 ## Endpoints

--- a/server/src/functions.rs
+++ b/server/src/functions.rs
@@ -1,5 +1,9 @@
+use std::sync::Arc;
+
+use axum::extract::State;
 use axum::http::StatusCode;
 use axum::{Json, debug_handler};
+use tokio::sync::Mutex;
 use yesser_todo_db::{SaveData, Task};
 
 use yesser_todo_errors::server_error::ServerError;
@@ -13,10 +17,12 @@ use yesser_todo_errors::server_error::ServerError;
 /// let tasks = json.0; // Vec<Task>
 /// ```
 #[debug_handler]
-pub async fn get_tasks() -> Result<(StatusCode, Json<Vec<Task>>), ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
-    Ok((StatusCode::OK, Json(save_data.get_tasks().clone())))
+pub async fn get_tasks(State(save_data): State<Arc<Mutex<SaveData>>>) -> Result<(StatusCode, Json<Vec<Task>>), ServerError> {
+    let tasks = {
+        let mut save_data = save_data.lock().await;
+        save_data.get_tasks().clone()
+    };
+    Ok((StatusCode::OK, Json(tasks)))
 }
 
 /// Creates and persists a new task with the given name.
@@ -36,10 +42,9 @@ pub async fn get_tasks() -> Result<(StatusCode, Json<Vec<Task>>), ServerError> {
 /// # }
 /// ```
 #[debug_handler]
-pub async fn add_task(Json(name): Json<String>) -> Result<(StatusCode, Json<Task>), ServerError> {
+pub async fn add_task(State(save_data): State<Arc<Mutex<SaveData>>>, Json(name): Json<String>) -> Result<(StatusCode, Json<Task>), ServerError> {
     println!("Adding task {}", name);
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+    let mut save_data = save_data.lock().await;
     if save_data.get_tasks().iter().any(|t| t.name == name) {
         return Err(ServerError::Conflict(name.into()));
     }
@@ -70,9 +75,8 @@ pub async fn add_task(Json(name): Json<String>) -> Result<(StatusCode, Json<Task
 /// // assert!(resp == StatusCode::OK || resp == StatusCode::NOT_FOUND);
 /// ```
 #[debug_handler]
-pub async fn remove_task(Json(index): Json<usize>) -> Result<StatusCode, ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn remove_task(State(save_data): State<Arc<Mutex<SaveData>>>, Json(index): Json<usize>) -> Result<StatusCode, ServerError> {
+    let mut save_data = save_data.lock().await;
 
     save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
 
@@ -101,9 +105,8 @@ pub async fn remove_task(Json(index): Json<usize>) -> Result<StatusCode, ServerE
 /// # }
 /// ```
 #[debug_handler]
-pub async fn done_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn done_task(State(save_data): State<Arc<Mutex<SaveData>>>, Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
+    let mut save_data = save_data.lock().await;
 
     save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
 
@@ -134,9 +137,8 @@ pub async fn done_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<Tas
 /// # }
 /// ```
 #[debug_handler]
-pub async fn undone_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn undone_task(State(save_data): State<Arc<Mutex<SaveData>>>, Json(index): Json<usize>) -> Result<(StatusCode, Json<Task>), ServerError> {
+    let mut save_data = save_data.lock().await;
 
     save_data.get_tasks().get(index).ok_or(ServerError::NotFound(index.into()))?;
 
@@ -159,9 +161,9 @@ pub async fn undone_task(Json(index): Json<usize>) -> Result<(StatusCode, Json<T
 /// # });
 /// ```
 #[debug_handler]
-pub async fn clear_tasks() -> Result<StatusCode, ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn clear_tasks(State(save_data): State<Arc<Mutex<SaveData>>>) -> Result<StatusCode, ServerError> {
+    let mut save_data = save_data.lock().await;
+
     println!("Clearing tasks");
     save_data.clear_tasks();
     save_data.save_tasks()?;
@@ -180,9 +182,8 @@ pub async fn clear_tasks() -> Result<StatusCode, ServerError> {
 /// clear_done_tasks().await;
 /// ```
 #[debug_handler]
-pub async fn clear_done_tasks() -> Result<StatusCode, ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn clear_done_tasks(State(save_data): State<Arc<Mutex<SaveData>>>) -> Result<StatusCode, ServerError> {
+    let mut save_data = save_data.lock().await;
 
     println!("Clearing done tasks");
     save_data.clear_done_tasks();
@@ -214,9 +215,8 @@ pub async fn clear_done_tasks() -> Result<StatusCode, ServerError> {
 /// }
 /// ```
 #[debug_handler]
-pub async fn get_index(Json(name): Json<String>) -> Result<(StatusCode, Json<usize>), ServerError> {
-    let mut save_data = SaveData::new();
-    save_data.load_tasks()?;
+pub async fn get_index(State(save_data): State<Arc<Mutex<SaveData>>>, Json(name): Json<String>) -> Result<(StatusCode, Json<usize>), ServerError> {
+    let mut save_data = save_data.lock().await;
     match yesser_todo_db::get_index(save_data.get_tasks(), &name) {
         None => Err(ServerError::NotFound(name.into())),
         Some(result) => Ok((StatusCode::OK, Json(result))),
@@ -229,268 +229,360 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_tasks_empty() {
-        clear_tasks().await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_add_task() {
-        clear_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
         let task_name = "Test task".to_string();
-        let (status, Json(task)) = add_task(Json(task_name.clone())).await.unwrap();
+        let (status, Json(task)) = add_task(State(save_data.clone()), Json(task_name.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(task.name, task_name);
         assert!(!task.done);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_add_multiple_tasks() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = add_task(Json("Task 3".to_string())).await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 3".to_string())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 3);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_remove_task_success() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        let status = remove_task(Json(0)).await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        let status = remove_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name, "Task 2");
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_remove_task_not_found() {
-        clear_tasks().await.unwrap();
-        let err = remove_task(Json(0)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let err = remove_task(State(save_data.clone()), Json(0)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn test_remove_task_out_of_bounds() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        let err = remove_task(Json(99)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        let err = remove_task(State(save_data.clone()), Json(99)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_done_task_success() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        let (status, Json(task)) = done_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
         assert_eq!(task.name, "Task 1");
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_done_task_not_found() {
-        clear_tasks().await.unwrap();
-        let err = done_task(Json(0)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let err = done_task(State(save_data.clone()), Json(0)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)))
     }
 
     #[tokio::test]
     async fn test_done_task_out_of_bounds() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        let err = done_task(Json(5)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        let err = done_task(State(save_data.clone()), Json(5)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn test_undone_task_success() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = done_task(Json(0)).await.unwrap();
-        let (status, Json(task)) = undone_task(Json(0)).await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(0)).await.unwrap();
+        let (status, Json(task)) = undone_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(!task.done);
         assert_eq!(task.name, "Task 1");
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_undone_task_not_found() {
-        clear_tasks().await.unwrap();
-        let err = undone_task(Json(0)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let err = undone_task(State(save_data.clone()), Json(0)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_undone_task_out_of_bounds() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        let err = undone_task(Json(10)).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        let err = undone_task(State(save_data.clone()), Json(10)).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_tasks() {
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = add_task(Json("Task 3".to_string())).await.unwrap();
-        clear_tasks().await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 3".to_string())).await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = add_task(Json("Task 3".to_string())).await.unwrap();
-        _ = done_task(Json(0)).await.unwrap();
-        _ = done_task(Json(2)).await.unwrap();
-        _ = clear_done_tasks().await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 3".to_string())).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(0)).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(2)).await.unwrap();
+        _ = clear_done_tasks(State(save_data.clone())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 1);
         assert_eq!(tasks[0].name, "Task 2");
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks_none_done() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = clear_done_tasks().await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = clear_done_tasks(State(save_data.clone())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 2);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_clear_done_tasks_all_done() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = done_task(Json(0)).await.unwrap();
-        _ = done_task(Json(1)).await.unwrap();
-        clear_done_tasks().await.unwrap();
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(0)).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(1)).await.unwrap();
+        clear_done_tasks(State(save_data.clone())).await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 0);
     }
 
     #[tokio::test]
     async fn test_get_index_found() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Task 2".to_string())).await.unwrap();
-        _ = add_task(Json("Task 3".to_string())).await.unwrap();
-        let (status, Json(index)) = get_index(Json("Task 2".to_string())).await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 3".to_string())).await.unwrap();
+        let (status, Json(index)) = get_index(State(save_data.clone()), Json("Task 2".to_string())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(index, 1);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_index_not_found() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Task 1".to_string())).await.unwrap();
-        let err = get_index(Json("Nonexistent".to_string())).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Task 1".to_string())).await.unwrap();
+        let err = get_index(State(save_data.clone()), Json("Nonexistent".to_string())).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)));
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_get_index_empty_list() {
-        clear_tasks().await.unwrap();
-        let err = get_index(Json("Any task".to_string())).await.unwrap_err();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        let err = get_index(State(save_data.clone()), Json("Any task".to_string())).await.unwrap_err();
         assert!(matches!(err, ServerError::NotFound(_)))
     }
 
     #[tokio::test]
     async fn test_done_undone_cycle() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Cycle task".to_string())).await.unwrap();
-        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Cycle task".to_string())).await.unwrap();
+        let (status, Json(task)) = done_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
 
-        let (status, Json(task)) = undone_task(Json(0)).await.unwrap();
+        let (status, Json(task)) = undone_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(!task.done);
-        let (status, Json(task)) = done_task(Json(0)).await.unwrap();
+        let (status, Json(task)) = done_task(State(save_data.clone()), Json(0)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert!(task.done);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_workflow_add_done_clear() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Workflow task 1".to_string())).await.unwrap();
-        _ = add_task(Json("Workflow task 2".to_string())).await.unwrap();
-        _ = add_task(Json("Workflow task 3".to_string())).await.unwrap();
-        _ = done_task(Json(1)).await;
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
 
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Workflow task 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Workflow task 2".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Workflow task 3".to_string())).await.unwrap();
+        _ = done_task(State(save_data.clone()), Json(1)).await;
+
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 3);
         assert!(!tasks[0].done);
         assert!(tasks[1].done);
         assert!(!tasks[2].done);
-        _ = clear_done_tasks().await.unwrap();
+        _ = clear_done_tasks(State(save_data.clone())).await.unwrap();
 
-        let (status, Json(tasks)) = get_tasks().await.unwrap();
+        let (status, Json(tasks)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks.len(), 2);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_add_task_with_special_characters() {
-        clear_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
         let special_name = "Task with spaces & symbols! @#$%ᕚ( Ŧคภςץ )ᕘ".to_string();
 
-        let (status, Json(task)) = add_task(Json(special_name.clone())).await.unwrap();
+        let (status, Json(task)) = add_task(State(save_data.clone()), Json(special_name.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(task.name, special_name);
 
-        let (status, Json(index)) = get_index(Json(special_name)).await.unwrap();
+        let (status, Json(index)) = get_index(State(save_data.clone()), Json(special_name)).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(status, StatusCode::OK);
         assert_eq!(index, 0);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 
     #[tokio::test]
     async fn test_persistence_across_operations() {
-        clear_tasks().await.unwrap();
-        _ = add_task(Json("Persist 1".to_string())).await.unwrap();
-        _ = add_task(Json("Persist 2".to_string())).await.unwrap();
-        let (status, Json(tasks_before)) = get_tasks().await.unwrap();
+        let mut save_data = SaveData::new();
+        save_data.load_tasks().unwrap();
+        let save_data = Arc::new(Mutex::new(save_data));
+
+        clear_tasks(State(save_data.clone())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Persist 1".to_string())).await.unwrap();
+        _ = add_task(State(save_data.clone()), Json("Persist 2".to_string())).await.unwrap();
+        let (status, Json(tasks_before)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks_before.len(), 2);
-        let (status, Json(tasks_after)) = get_tasks().await.unwrap();
+        let (status, Json(tasks_after)) = get_tasks(State(save_data.clone())).await.unwrap();
         assert_eq!(status, StatusCode::OK);
         assert_eq!(tasks_after.len(), 2);
         assert_eq!(tasks_before[0].name, tasks_after[0].name);
         assert_eq!(tasks_before[1].name, tasks_after[1].name);
-        clear_tasks().await.unwrap();
+        clear_tasks(State(save_data.clone())).await.unwrap();
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,11 +1,16 @@
 mod functions;
 
+use std::process::exit;
+use std::sync::Arc;
+
 use crate::functions::{add_task, clear_done_tasks, clear_tasks, done_task, get_index, get_tasks, remove_task, undone_task};
 use axum::routing::delete;
 use axum::{
     Router,
     routing::{get, post},
 };
+use tokio::sync::Mutex;
+use yesser_todo_db::SaveData;
 
 /// Binary entry point that configures HTTP routes and starts the Axum server.
 ///
@@ -21,6 +26,16 @@ use axum::{
 /// ```
 #[tokio::main]
 async fn main() {
+    let mut save_data = SaveData::new();
+    match save_data.load_tasks() {
+        Ok(()) => {}
+        Err(err) => {
+            eprintln!("An error occured while loading tasks: {err}");
+            exit(1)
+        }
+    }
+    let save_data: Arc<Mutex<SaveData>> = Arc::new(Mutex::new(save_data));
+
     let router = Router::new()
         .route("/tasks", get(get_tasks))
         .route("/add", post(add_task))
@@ -29,7 +44,8 @@ async fn main() {
         .route("/undone", post(undone_task))
         .route("/clear", delete(clear_tasks))
         .route("/cleardone", delete(clear_done_tasks))
-        .route("/index", get(get_index));
+        .route("/index", get(get_index))
+        .with_state(save_data);
 
     let listener = tokio::net::TcpListener::bind("0.0.0.0:6982").await.unwrap();
     axum::serve(listener, router).await.unwrap();

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,7 +30,7 @@ async fn main() {
     match save_data.load_tasks() {
         Ok(()) => {}
         Err(err) => {
-            eprintln!("An error occured while loading tasks: {err}");
+            eprintln!("An error occurred while loading tasks: {err}");
             exit(1)
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Server now loads task data once at startup and exposes a shared, synchronized application state to all endpoints, improving efficiency and consistency.
  * Request handlers were updated to operate on this shared state rather than creating/loading data per call.
* **Tests**
  * Unit tests updated to initialize and pass the shared state into handler tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->