### PR TITLE
Add --local (-l) flag to ignore cloud config

### DIFF
--- a/cli/src/bin/todo/args.rs
+++ b/cli/src/bin/todo/args.rs
@@ -12,6 +12,10 @@ pub(crate) struct TodoArgs {
     /// The operation to do in the task list.
     #[clap(subcommand)]
     pub(crate) command: Command,
+
+    /// Ignore the cloud config and work with local tasks.
+    #[arg(short, long)]
+    pub(crate) local: bool,
 }
 
 #[derive(Debug, Subcommand)]

--- a/cli/src/bin/todo/main.rs
+++ b/cli/src/bin/todo/main.rs
@@ -36,11 +36,13 @@ fn main() {
         }
     }
 
-    let mut client: Option<Client> = None;
-
-    if let Some((hostname, port)) = process_cloud_config() {
-        client = Some(Client::new(hostname, Some(port)));
-    }
+    let mut client: Option<Client> = if !args.local
+        && let Some((hostname, port)) = process_cloud_config()
+    {
+        Some(Client::new(hostname, Some(port)))
+    } else {
+        None
+    };
 
     match args.command.execute(data.get_tasks(), &mut client) {
         Ok(()) => match args.command {

--- a/cli/src/bin/todo/main.rs
+++ b/cli/src/bin/todo/main.rs
@@ -36,9 +36,7 @@ fn main() {
         }
     }
 
-    let mut client: Option<Client> = if !args.local
-        && let Some((hostname, port)) = process_cloud_config()
-    {
+    let mut client: Option<Client> = if let Some((hostname, port)) = process_cloud_config(Some(&args)) {
         Some(Client::new(hostname, Some(port)))
     } else {
         None

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -72,7 +72,6 @@ mod tests {
         }
     }
 
-    #[cfg(test)]
     fn construct_todo_args(local: bool) -> TodoArgs {
         TodoArgs {
             command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -1,6 +1,8 @@
 use yansi::{Color::Green, Style};
 use yesser_todo_db::SaveData;
 
+use crate::args::TodoArgs;
+
 pub(crate) const DONE_STYLE: Style = Green.strike();
 
 /// Return the saved cloud server host and port when available.
@@ -20,11 +22,17 @@ pub(crate) const DONE_STYLE: Style = Green.strike();
 ///     panic!("expected cloud config");
 /// }
 /// ```
-pub(crate) fn process_cloud_config() -> Option<(String, String)> {
-    SaveData::get_cloud_config().unwrap_or_else(|err| {
-        eprintln!("Warning: Failed to read cloud config: {err}. Proceeding with local mode.");
+pub(crate) fn process_cloud_config(args: Option<&TodoArgs>) -> Option<(String, String)> {
+    if let Some(args) = args
+        && args.local
+    {
         None
-    })
+    } else {
+        SaveData::get_cloud_config().unwrap_or_else(|err| {
+            eprintln!("Warning: Failed to read cloud config: {err}. Proceeding with local mode.");
+            None
+        })
+    }
 }
 
 #[cfg(test)]

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -5,17 +5,27 @@ use crate::args::TodoArgs;
 
 pub(crate) const DONE_STYLE: Style = Green.strike();
 
-/// Return the saved cloud server host and port when available.
+/// Return the saved cloud server host and port if available.
+///
+/// # Arguments
+///
+/// * `args` - An optional `TodoArgs` object. Will be used to determine wheter local mode is on.
 ///
 /// # Returns
 ///
-/// `Some((host, port))` if a readable cloud configuration exists, `None` otherwise.
+/// If `args` is `Some`, and `args.local` is `true`, returns `None`.  
+/// If `args` is None, local mode will be assumed false.
+///
+/// Returns an optional `(String, String)` in the format `(host URL, port)` based on whether the
+/// cloud config is saved.  
+/// If an error occurs while reading the cloud config, an error message will
+/// be printed and None will be returned (local mode will be assumed).
 ///
 /// # Examples
 ///
 /// ```
 /// // Suppose SaveData::get_cloud_config() returns Ok(Some(("example.com".into(), "6982".into())))
-/// if let Some((host, port)) = process_cloud_config() {
+/// if let Some((host, port)) = process_cloud_config(None) {
 ///     assert_eq!(host, "example.com");
 ///     assert_eq!(port, "6982");
 /// } else {

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -9,7 +9,7 @@ pub(crate) const DONE_STYLE: Style = Green.strike();
 ///
 /// # Arguments
 ///
-/// * `args` - An optional `TodoArgs` object. Will be used to determine wheter local mode is on.
+/// * `args` - An optional `TodoArgs` object. Will be used to determine whether local mode is on.
 ///
 /// # Returns
 ///

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -50,16 +50,80 @@ mod tests {
 
     #[test]
     fn test_process_cloud_config_returns_option() {
-        let result = process_cloud_config();
+        let result = process_cloud_config(None);
         assert!(result.is_some() || result.is_none());
     }
 
     #[test]
     fn test_process_cloud_config_tuple_structure() {
-        if let Some((host, port)) = process_cloud_config() {
+        if let Some((host, port)) = process_cloud_config(None) {
             assert!(!host.is_empty() || host.is_empty());
             assert!(!port.is_empty() || port.is_empty());
         }
+    }
+
+    #[test]
+    fn test_process_cloud_config_args_is_some_local_false() {
+        const HOST: &str = "http://127.0.0.1";
+        const PORT: &str = yesser_todo_api::DEFAULT_PORT;
+
+        let previous_cloud_config = SaveData::get_cloud_config().unwrap();
+
+        SaveData::save_cloud_config(HOST, PORT).unwrap();
+        let result = process_cloud_config(Some(&TodoArgs {
+            command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),
+            local: false,
+        }));
+
+        match previous_cloud_config {
+            Some((host, port)) => SaveData::save_cloud_config(&host, &port).unwrap(),
+            None => SaveData::remove_cloud_config().unwrap(),
+        };
+
+        let (host, port) = result.unwrap();
+        assert_eq!(host, HOST);
+        assert_eq!(port, PORT);
+    }
+
+    #[test]
+    fn test_process_cloud_config_args_is_some_local_true() {
+        const HOST: &str = "http://127.0.0.1";
+        const PORT: &str = yesser_todo_api::DEFAULT_PORT;
+
+        let previous_cloud_config = SaveData::get_cloud_config().unwrap();
+
+        SaveData::save_cloud_config(HOST, PORT).unwrap();
+        let result = process_cloud_config(Some(&TodoArgs {
+            command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),
+            local: true,
+        }));
+
+        match previous_cloud_config {
+            Some((host, port)) => SaveData::save_cloud_config(&host, &port).unwrap(),
+            None => SaveData::remove_cloud_config().unwrap(),
+        };
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_process_cloud_config_args_is_none() {
+        const HOST: &str = "http://127.0.0.1";
+        const PORT: &str = yesser_todo_api::DEFAULT_PORT;
+
+        let previous_cloud_config = SaveData::get_cloud_config().unwrap();
+
+        SaveData::save_cloud_config(HOST, PORT).unwrap();
+        let result = process_cloud_config(None);
+
+        match previous_cloud_config {
+            Some((host, port)) => SaveData::save_cloud_config(&host, &port).unwrap(),
+            None => SaveData::remove_cloud_config().unwrap(),
+        };
+
+        let (host, port) = result.unwrap();
+        assert_eq!(host, HOST);
+        assert_eq!(port, PORT);
     }
 
     #[test]

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -72,6 +72,14 @@ mod tests {
         }
     }
 
+    #[cfg(test)]
+    fn construct_todo_args(local: bool) -> TodoArgs {
+        TodoArgs {
+            command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),
+            local,
+        }
+    }
+
     #[test]
     fn test_process_cloud_config_args_is_some_local_false() {
         const HOST: &str = "http://127.0.0.1";
@@ -80,10 +88,7 @@ mod tests {
         let previous_cloud_config = SaveData::get_cloud_config().unwrap();
 
         SaveData::save_cloud_config(HOST, PORT).unwrap();
-        let result = process_cloud_config(Some(&TodoArgs {
-            command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),
-            local: false,
-        }));
+        let result = process_cloud_config(Some(&construct_todo_args(false)));
 
         match previous_cloud_config {
             Some((host, port)) => SaveData::save_cloud_config(&host, &port).unwrap(),
@@ -103,10 +108,7 @@ mod tests {
         let previous_cloud_config = SaveData::get_cloud_config().unwrap();
 
         SaveData::save_cloud_config(HOST, PORT).unwrap();
-        let result = process_cloud_config(Some(&TodoArgs {
-            command: crate::args::Command::Add(crate::args::TasksCommand { tasks: vec!["".to_string()] }),
-            local: true,
-        }));
+        let result = process_cloud_config(Some(&construct_todo_args(true)));
 
         match previous_cloud_config {
             Some((host, port)) => SaveData::save_cloud_config(&host, &port).unwrap(),


### PR DESCRIPTION
Closes #40 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--local` / `-l` flag to run the CLI in local-only mode; when used the app ignores saved cloud configuration and will not initialize a remote client.

* **Tests**
  * Updated and expanded tests to cover flag behavior and the different configuration/initialization paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->