### PR TITLE
Add `todo cloud migrate`

### DIFF
--- a/cli/src/bin/todo/args.rs
+++ b/cli/src/bin/todo/args.rs
@@ -64,6 +64,15 @@ pub(crate) struct CloudCommand {
     pub port: Option<String>,
 }
 
+#[derive(Debug, Args)]
+pub(crate) struct CloudMigrateCommand {
+    pub host: String,
+    pub port: Option<String>,
+    /// Keep local tasks and copy them to server instead of deleting them locally
+    #[arg(short, long)]
+    pub keep: bool,
+}
+
 #[derive(Debug, Subcommand)]
 pub(crate) enum CloudSubcommand {
     /// Connect to a cloud server.

--- a/cli/src/bin/todo/args.rs
+++ b/cli/src/bin/todo/args.rs
@@ -81,6 +81,8 @@ pub(crate) enum CloudSubcommand {
     Disconnect,
     /// View server configuration.
     Show,
+    /// Migrate local tasks to a cloud server.
+    Migrate(CloudMigrateCommand),
 }
 
 impl Command {
@@ -141,5 +143,6 @@ fn handle_cloud_subcommand(cloud_subcommand: &CloudSubcommand, data: &mut dyn Sa
         CloudSubcommand::Connect(cloud_command) => handle_connect(cloud_command, data),
         CloudSubcommand::Disconnect => handle_disconnect(data),
         CloudSubcommand::Show => handle_show_server(data),
+        CloudSubcommand::Migrate(cloud_command) => handle_migrate(cloud_command, data),
     }
 }

--- a/cli/src/bin/todo/command_impl_cloud.rs
+++ b/cli/src/bin/todo/command_impl_cloud.rs
@@ -6,9 +6,10 @@ use yesser_todo_db::{DatabaseError, SaveData, Task};
 use yesser_todo_errors::command_error::CommandError;
 
 use crate::{
-    args::{ClearCommand, CloudCommand, TasksCommand},
+    args::{ClearCommand, CloudCommand, CloudMigrateCommand, TasksCommand},
+    command_impl::{handle_clear, handle_remove},
     db_error_wrap::DatabaseErrorWrapper,
-    utils::DONE_STYLE,
+    utils::{DONE_STYLE, get_client},
 };
 
 /// Checks whether a task with the given name exists on the cloud server.
@@ -624,6 +625,45 @@ pub(crate) fn handle_disconnect_old(data: &dyn SaveData) -> Result<(), CommandEr
     handle_disconnect(data)
 }
 
+pub(crate) fn handle_migrate(command: &CloudMigrateCommand, data: &mut dyn SaveData) -> Result<(), CommandError> {
+    let cloud_command = CloudCommand {
+        host: command.host.clone(),
+        port: command.port.clone(),
+    };
+    handle_connect(&cloud_command, data)?;
+
+    let mut client = match get_client(None, data) {
+        Some(client) => client,
+        None => return Err(CommandError::ConnectionError { name: "".into() }),
+    };
+
+    let tasks = data.get_tasks().clone();
+    for task in tasks {
+        let tasks_command = TasksCommand { tasks: vec![task.name] };
+
+        if let Err(err) = handle_add_cloud(&tasks_command, &mut client)
+            && !matches!(err, CommandError::TaskExists { name: _ })
+        {
+            Err(err)?;
+        }
+
+        if task.done {
+            handle_done_undone_cloud(&tasks_command, &mut client, true)?;
+        }
+    }
+    if !command.keep {
+        let clear_command = ClearCommand { done: false };
+        handle_clear(&clear_command, data.get_tasks())?;
+        if let Err(err) = data.save_tasks() {
+            return Err(CommandError::DataError {
+                what: "cleared moved tasks".into(),
+                err,
+            });
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use yesser_todo_db::JsonSaveData;
@@ -983,5 +1023,4 @@ mod tests {
         let (data, _dir) = make_data();
         assert!(handle_show_server(&data).is_ok());
     }
-
 }

--- a/cli/src/bin/todo/main.rs
+++ b/cli/src/bin/todo/main.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use yesser_todo_api::Client;
 use yesser_todo_db::{JsonSaveData, SaveData};
 
-use crate::utils::process_cloud_config;
+use crate::utils::get_client;
 
 /// Application entry point for the Todo CLI.
 ///
@@ -41,11 +41,7 @@ fn main() {
         }
     }
 
-    let mut client: Option<Client> = if let Some((hostname, port)) = process_cloud_config(Some(&args), &*data) {
-        Some(Client::new(hostname, Some(port)))
-    } else {
-        None
-    };
+    let mut client: Option<Client> = get_client(Some(&args), &*data);
 
     match args.command.execute(&mut *data, &mut client) {
         Ok(()) => match args.command {

--- a/cli/src/bin/todo/utils.rs
+++ b/cli/src/bin/todo/utils.rs
@@ -1,4 +1,5 @@
 use yansi::{Color::Green, Style};
+use yesser_todo_api::Client;
 use yesser_todo_db::SaveData;
 
 use crate::args::TodoArgs;
@@ -38,6 +39,10 @@ pub(crate) fn process_cloud_config(args: Option<&TodoArgs>, data: &dyn SaveData)
             None
         })
     }
+}
+
+pub(crate) fn get_client(args: Option<&TodoArgs>, data: &dyn SaveData) -> Option<Client> {
+    process_cloud_config(args, data).map(|(hostname, port)| Client::new(hostname, Some(port)))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #37 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cloud migration command for transferring local tasks to a specified cloud host and port.
  * Preserves task completion status during migration and skips tasks already present in the cloud.
  * Local incomplete tasks are cleared after a successful migration by default; use the keep option to retain them.
* **Improvements**
  * Cloud connection handling is now more consistent across CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->